### PR TITLE
update deno_mysql for MariaDB support

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,6 @@
 export { assert, assertEquals, assertThrowsAsync } from "https://deno.land/std@v0.24.0/testing/asserts.ts";
 export { runTests, test, TestFunction } from "https://deno.land/std@v0.24.0/testing/mod.ts";
-export { Client, ClientConfig, Connection } from "https://deno.land/x/mysql@1.3.0/mod.ts";
+export { Client, ClientConfig, Connection } from "https://deno.land/x/mysql@1.4.0/mod.ts";
 export { Join, Order, Query, replaceParams, Where } from "https://deno.land/x/sql_builder@1.3.5/mod.ts";
 
 import "./src/Reflect.ts";


### PR DESCRIPTION
bump `deno_mysql` from `1.3.0` to `1.4.0`