### PR TITLE
Optional length on field type TEXT when sync Model

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -26,7 +26,7 @@ export async function sync(client: Client, model: BaseModel, force: boolean) {
           type = `TINYINT(1)`;
           break;
         case FieldType.TEXT:
-          type = `TEXT(${field.length})`;
+          type = `TEXT(${field.length || 65535})`;
           break;
         case FieldType.LONGTEXT: {
           type = `LONGTEXT`;


### PR DESCRIPTION
`dso.sync` break when there is no length defined in TEXT field, so I default it to 64kb.