### PR TITLE
Multiple indexes, multi column indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ import {
   dso,
   Field,
   FieldType,
+  Index,
+  IndexType,
   Join,
   Model,
   Where
@@ -38,13 +40,14 @@ class UserModel extends BaseModel {
 
   @Field({ type: FieldType.STRING, length: 30 })
   password: string;
-  
-  @Field({ 
-    type: FieldType.STRING, 
-    unique: true, 
-    length: 20})
-  phoneNumber?: string;
-}
+
+  // Index can be created [index/unique/spatial/fulltext] for each field
+  @Field({ type: FieldType.STRING, length: 30, unique: true })
+  email: string;
+
+  // Multi column index can be defined by decorated @Index
+  @Index({ type: IndexType.UNIQUE, columns: ["username","namespace"] })
+  public myUniqueIndex!: Index;
 }
 
 const userModel = dso.define(UserModel);
@@ -74,8 +77,7 @@ async function main() {
   // You can add records using insert method
   const insertId = await userModel.insert({
     name: "user1",
-    password: "password",
-    phoneNumber: "08135539123"
+    password: "password"
   });
 
   // You can use the Model.findById method to get a record
@@ -98,6 +100,7 @@ async function main() {
   console.log("Found user by where eq clause:", userWhere);
   console.log("All users by where eq clause:", userAll);
   console.log("All users by where like clause:", userLike);
+  console.log("User has these columns in index:", user.myUniqueIndex.columns);
 }
 main();
 ```
@@ -239,4 +242,16 @@ Field type describes the following properties of a field
 | unique        | boolean                              | false         | database unique index?  
 | spatial       | boolean                              | false         | database spatial index?  
 | fullText      | boolean                              | false         | database fullText index?  
-| index         | boolean                              | false         | database non unique index?  
+| index         | boolean                              | false         | database non unique index?
+
+
+#### Index
+Following types of an index are available
+
+| key           | multi column                          
+| ------------- | ------------------------------------ 
+| index         | true                                 
+| unique        | true                                 
+| spatial       | false                                
+| fulltext      | true                                 
+  

--- a/mod.ts
+++ b/mod.ts
@@ -9,5 +9,6 @@ export {
 } from "./deps.ts";
 export { dso } from "./src/dso.ts";
 export * from "./src/field.ts";
+export * from "./src/index.ts";
 export * from "./src/model.ts";
 export * from "./src/util.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,30 @@
+import {BaseModel} from "./model.ts";
+
+export enum IndexType {
+    INDEX,
+    UNIQUE,
+    SPATIAL,
+    FULLTEXT
+}
+
+export const columnIndexesList: { [key: number]: string; } = {
+    [IndexType.INDEX]: "INDEX",
+    [IndexType.UNIQUE]: "UNIQUE",
+    [IndexType.SPATIAL]: "SPATIAL INDEX",
+    [IndexType.FULLTEXT]: "FULLTEXT"
+};
+
+export interface Index {
+    type: keyof typeof columnIndexesList,
+    property?: string;
+    columns: Array<string>
+}
+
+/** Field Decorator */
+export function Index(options: Index) {
+    return (target: BaseModel, property: string) => {
+        const indexes = target.indexes;
+        indexes.push({ ...options, property });
+        Reflect.defineMetadata("model:indexes", indexes, target);
+    };
+}

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2,6 +2,7 @@ import { assert, Client } from "../deps.ts";
 import { dso } from "../mod.ts";
 import { FieldType, Defaults } from "./field.ts";
 import { BaseModel } from "./model.ts";
+import {columnIndexesList, Index} from "./index.ts";
 
 export async function sync(client: Client, model: BaseModel, force: boolean) {
   if (force) {
@@ -9,73 +10,71 @@ export async function sync(client: Client, model: BaseModel, force: boolean) {
   }
 
   let defs = model.modelFields
-    .map((field) => {
-      let def = field.name;
-      let type = "";
-      switch (field.type) {
-        case FieldType.STRING:
-          type = `VARCHAR(${field.length || 255})`;
-          break;
-        case FieldType.INT:
-          type = `INT(${field.length || 11})`;
-          break;
-        case FieldType.DATE:
-          type = `TIMESTAMP`;
-          break;
-        case FieldType.BOOLEAN:
-          type = `TINYINT(1)`;
-          break;
-        case FieldType.TEXT:
-          type = `TEXT(${field.length || 65535})`;
-          break;
-        case FieldType.LONGTEXT: {
-          type = `LONGTEXT`;
-          break;
+      .map((field) => {
+        let def = field.name;
+        let type = "";
+        switch (field.type) {
+          case FieldType.STRING:
+            type = `VARCHAR(${field.length || 255})`;
+            break;
+          case FieldType.INT:
+            type = `INT(${field.length || 11})`;
+            break;
+          case FieldType.DATE:
+            type = `TIMESTAMP`;
+            break;
+          case FieldType.BOOLEAN:
+            type = `TINYINT(1)`;
+            break;
+          case FieldType.TEXT:
+            type = `TEXT(${field.length || 65535})`;
+            break;
+          case FieldType.LONGTEXT: {
+            type = `LONGTEXT`;
+            break;
+          }
+          case FieldType.GeoPOINT: {
+            type = `POINT`;
+            break;
+          }
         }
-        case FieldType.GeoPOINT: {
-          type = `POINT`;
-          break;
+        def += ` ${type}`;
+        if (field.notNull) def += " NOT NULL";
+        if (field.default != null) {
+          if (field.default === Defaults.NULL) {
+            def += ` NULL DEFAULT NULL`;
+          } else {
+            def += ` DEFAULT ${field.default}`;
+          }
         }
-      }
-      def += ` ${type}`;
-      if (field.notNull) def += " NOT NULL";
-      if (field.default != null) {
-        if (field.default === Defaults.NULL) {
-          def += ` NULL DEFAULT NULL`;
-        } else {
-          def += ` DEFAULT ${field.default}`;
+        if (field.autoIncrement) def += " AUTO_INCREMENT";
+        if (field.autoUpdate) {
+          assert(
+              field.type === FieldType.DATE,
+              "AutoUpdate only support Date field",
+          );
+          def += ` ON UPDATE CURRENT_TIMESTAMP()`;
         }
-      }
-      if (field.autoIncrement) def += " AUTO_INCREMENT";
-      if (field.autoUpdate) {
-        assert(
-          field.type === FieldType.DATE,
-          "AutoUpdate only support Date field",
-        );
-        def += ` ON UPDATE CURRENT_TIMESTAMP()`;
-      }
-      return def;
-    })
-    .join(", ");
+        return def;
+      })
+      .join(", ");
 
   if (model.primaryKey) {
     defs += `, PRIMARY KEY (${model.primaryKey.name})`;
   }
 
-  if (model.uniqueKey) {
-    defs += `, UNIQUE (${model.uniqueKey.name})`;
-  }
-  if (model.indexKey) {
-    defs += `, INDEX (${model.indexKey.name})`;
-  }
-
-  if (model.spatialKey) {
-    defs += `, SPATIAL INDEX (${model.spatialKey.name})`;
+  // get field indexes
+  for (const arrayKey in model.columnIndexes) {
+    const indexes = model.columnIndexes[arrayKey];
+    for (const key of indexes)
+      defs += `, ${columnIndexesList[arrayKey]} (${key.name})`;
   }
 
-  if (model.fullTextKey) {
-    defs += `, FULLTEXT (${model.fullTextKey.name})`;
-  }
+  // get model indexes
+  model.indexes.forEach((index: Index) => {
+    defs += `, ${columnIndexesList[index.type]} (${index.columns.join(", ")})`;
+  });
+
   const sql = [
     "CREATE TABLE IF NOT EXISTS",
     model.modelName,
@@ -84,7 +83,8 @@ export async function sync(client: Client, model: BaseModel, force: boolean) {
     ")",
     "ENGINE=InnoDB DEFAULT CHARSET=utf8;",
   ].join(" ");
-  
+  console.log(sql);
+
   dso.showQueryLog && console.log(`\n[ DSO:SYNC ]\nSQL:\t ${sql}\n`);
   const result = await client.execute(sql);
   dso.showQueryLog && console.log(`REUSLT:\t`, result, `\n`);


### PR DESCRIPTION
As long as commit #26 allows you to create other Indexes aside Primary Key it doesn't allows you to create multiple indexes and indexes over multiple columns. 

## Multiple indexes:
### **old behavior** (bug?): 
Because of `find()` in `model.ts` found on [row 46](https://github.com/manyuanrong/dso/commit/4e3b7c707a0d368df8fdf13f865a74fd67ace9de#diff-a6322b30cb17d35f81779ff7980ea4c3R46) only one column can be unique (or have a same index). Another definitions will be ignored.

### **new behavior**
Every defined index will be used. It uses  `filter()` and is iterating through the whole array of indexes instead of taking only first index.

## Multicolumn indexes
You can create separate index for multiple columns.    
For example: If you want to create unique combination of username and email, you can define it in your model:
```typescript
@Index({ type: IndexType.UNIQUE, columns: ["username","email"] })
public myIndex!: Index;
```

## Common improvments
- indexes now labeled as a _index_ (_indexes_) instead of _key_ (_keys_)
- defined interface for index `Index`
- defined index type enum `IndexType`
- defined index list with SQL translation `columnIndexesList`