### PR TITLE
refactor: std versions prefixed with 'v' were deprecated

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -2,7 +2,7 @@ export {
   assert,
   assertEquals,
   assertThrowsAsync,
-} from "https://deno.land/std@v0.51.0/testing/asserts.ts";
+} from "https://deno.land/std@0.51.0/testing/asserts.ts";
 export {
   Client,
   ClientConfig,


### PR DESCRIPTION
<img width="1138" alt="Screen Shot 2021-03-27 at 09 55 46" src="https://user-images.githubusercontent.com/25542415/112708110-9c3e1700-8ee2-11eb-8a73-cc655e22a3cd.png">
